### PR TITLE
Remove extraenous whitespace in example

### DIFF
--- a/includes/full-example.js
+++ b/includes/full-example.js
@@ -1,7 +1,7 @@
 { 
   "uber" :
   {
-    "version" : " 1.0",
+    "version" : "1.0",
     "data" :
     [
       {"rel" : "self", "url" : "http://example.org/"},


### PR DESCRIPTION
The JSON Full example had an extra space in the value of the "version" attribute. Thus it was " 1.0" rather than "1.0".
