### PR TITLE
Fixed typo in RFC link.

### DIFF
--- a/uber-hypermedia.asciidoc
+++ b/uber-hypermedia.asciidoc
@@ -130,7 +130,7 @@ The +<data>+ element is the key element in the model. A valid Uber message SHOUL
   The document-wide unique identifier for this element. The value of +id+ must begin with a letter ([A-Za-z]) and may be followed by any number of letters, digits ([0-9]), hyphens ("-"), underscores ("_"), colons (":"), and periods ("."). If the +id+ attribute is present, it SHOULD be treated as an in-document reference as described in section 3.5 of RFC3986 <<rfc3986,[RFC3986]>>.
 
 +name+::
-  A document-wide non-unique identifer for this element. The value of +name+ must begin with a letter ([A-Za-z]) and may be followed by any number of letters, digits ([0-9]), hyphens ("-"), underscores ("_"), colons (":"), and periods ("."). If the +name+ attribute is present it MAY be used as a variable in the Uber +model+ attribute as described in <<rfc6570,[RFC65670]>>.
+  A document-wide non-unique identifer for this element. The value of +name+ must begin with a letter ([A-Za-z]) and may be followed by any number of letters, digits ([0-9]), hyphens ("-"), underscores ("_"), colons (":"), and periods ("."). If the +name+ attribute is present it MAY be used as a variable in the Uber +model+ attribute as described in <<rfc6570,[RFC6570]>>.
 
 +rel+::
   Contains a space-separated list of link relation values. These values SHOULD conform to those described in RFC5988 <<rfc5988, [RFC5988]>>.

--- a/uber-hypermedia.html
+++ b/uber-hypermedia.html
@@ -921,7 +921,7 @@ Dublin Core Metadata Element Set, Version 1.1 <a href="#dc-rel">[DC-REL]</a>
 </dt>
 <dd>
 <p>
-  A document-wide non-unique identifer for this element. The value of <tt>name</tt> must begin with a letter ([A-Za-z]) and may be followed by any number of letters, digits ([0-9]), hyphens ("-"), underscores ("_"), colons (":"), and periods ("."). If the <tt>name</tt> attribute is present it MAY be used as a variable in the Uber <tt>model</tt> attribute as described in <a href="#rfc6570">[RFC65670]</a>.
+  A document-wide non-unique identifer for this element. The value of <tt>name</tt> must begin with a letter ([A-Za-z]) and may be followed by any number of letters, digits ([0-9]), hyphens ("-"), underscores ("_"), colons (":"), and periods ("."). If the <tt>name</tt> attribute is present it MAY be used as a variable in the Uber <tt>model</tt> attribute as described in <a href="#rfc6570">[RFC6570]</a>.
 </p>
 </dd>
 <dt class="hdlist1">


### PR DESCRIPTION
The text for the link to RFC 6570 had the text 65670.
