### PR TITLE
Move address data to its own element

### DIFF
--- a/includes/full-example.js
+++ b/includes/full-example.js
@@ -82,7 +82,10 @@
                 [
                   {
                     "name" : "name", 
-                    "value" : "Home",
+                    "value" : "Home"
+                  },
+                  {
+                    "name" : "address",
                     "data" :
                     [
                       {"name" : "streetAddress", "value" : "123 Main Street"},
@@ -101,7 +104,10 @@
                 [
                   {
                     "name" : "name", 
-                    "value" : "Work",
+                    "value" : "Work"
+                  },
+                  {
+                    "name" : "address",
                     "data" : 
                     [
                       {"name" : "streetAddress", "value" : "1456 Grand Ave."},


### PR DESCRIPTION
In the full XML example, the address data is nested within a data element with the name of "address," but in the JSON example, it is nested under a data element with "name" as name.

This change moves the address data to an "address" data element.

This brings up something (which I'll outline in my hyperdescribe spec), but in the JSON variant, a data element MUST NOT have both a @value and @data attribute. 
