### PR TITLE
Add a `range` Base-level Constraint

### DIFF
--- a/proposals/uber-templates-mca.asciidoc
+++ b/proposals/uber-templates-mca.asciidoc
@@ -142,6 +142,9 @@ Below is a list of proposed base-level constraints that MUST be supported if an 
 +<data name="pattern">+::
   The contents of the +value+ property contains a <<poxisre, [POSIX-RE]>> regular expression that SHOULD be applied to the field.
 
++<data name="range">+::
+  The contents of the +value+ property contains a range expression: a number followed by a - followed by a number. Ranges are always inclusive. For instance, +12-15+ would be satisfied by any of: 12, 13, 14 or 15.
+
 ==== Constraint Extensibility
 Since constraints are established using reserved words for the +name+ property of a +data+ element, extending the list of supported constraints is done by registering a new reserved word and documenting how implementors can author and interpret that element and any possible child elements.
 


### PR DESCRIPTION
This adds a `range` base-level constraint for use inside the `template` tag.

The use case I'm thinking of is stuff like this:

``` xml
<uber>
  <data rel="collection users" url="/users" template="#user_index_template" action="read">
    <data rel="item user" url="/users/8765" action="read">
      <data name="name">Ben</data>
      <!-- ... -->
    </data>
    <!-- ... -->
  </data>

  <template id="user_index_template">
    <data name="page">
      <data name="pattern">\d+</data>
    </data>

    <data name="per_page">
      <data name="range">1-100</data> <!-- The server will only ever return a maximum of 100 users per page. -->
    </data>

    <data name="sort_by">
      <data name="options">
        <data>name</name>
        <data>joined_at</name>
      </data>
    </data>
  </template>
</uber>
```

I didn't update the html file because when I tried to run asciidoc, there were more differences than just my chance, so I figured there were some configurations I didn't have or something. I've never used asciidoc before, so... Lemme know if you want me to do that.

Also, lemme know if this seems like... too much cruft without commensurate benefit at this early stage in the life of the spec.
