### PR TITLE
Fix full JSON example

### DIFF
--- a/includes/full-example.js
+++ b/includes/full-example.js
@@ -6,118 +6,112 @@
     [
       {"rel" : ["self"], "url" : "http://example.org/"},
       {"rel" : ["profile"], "url" : "http://example.org/profiles/people-and-places"},
-      
       {
+        "id" : "people", 
+        "rel" : ["collection","http://example.org/rels/people"], 
+        "url" : "http://example.org/people/",
         "data" : 
         [
           {
-            "id" : "people", 
-            "rel" : ["collection","http://example.org/rels/people"], 
+            "name" : "create", 
+            "rel" : ["http://example.org/rels/create"], 
             "url" : "http://example.org/people/",
+            "model" : "g={givenName}&f={familyName}&e={email}",
+            "action" : "append"
+          },
+          {
+            "name" : "search",
+            "rel" : ["search","collection"],
+            "url" : "http://example.org/people/search",
+            "model" : "?g={givenName}&f={familyName}&e={email}"
+          },
+          {
+            "name" : "person",
+            "rel" : ["item","http://example.org/rels/person"],
+            "url" : "http://example.org/people/1",
+            "data" :
+            [
+              {"name" : "givenName", "value" : "Mike"},
+              {"name" : "familyName", "value" : "Amundsen"},
+              {"name" : "email", "value" : "mike@example.org"},
+              {"name" : "avatarUrl", "transclude" : "true", 
+                  "url" : "http://example.org/avatars/1", 
+                  "value" : "User Photo",
+                  "accepting" : ["image/*"]
+              }
+            ]
+          },
+          {
+            "name" : "person",
+            "rel" : ["item","http://example.org/rels/person"],
+            "url" : "http://example.org/people/2",
+            "data" :
+            [
+              {"name" : "givenName", "value" : "Mildred"},
+              {"name" : "familyName", "value" : "Amundsen"},
+              {"name" : "email", "value" : "mildred@example.org"},
+              {"name" : "avatarUrl", "transclude" : "true", 
+                  "url" : "http://example.org/avatars/2", 
+                  "value" : "User Photo",
+                  "accepting" : ["image/*"]
+              }
+            ]
+          }
+        ]
+      },
+      
+      {
+        "id" : "places", 
+        "rel" : ["collection","http://example.org/rels/places"], 
+        "url" : "http://example.org/places/",
+        "data" :
+        [
+          {
+            "name" : "search",
+            "rel" : ["search","collection"],
+            "url" : "http://example.org/places/search",
+            "model" : "?r={addressRegion}&l={addressLocality}&p={postalCode}"
+          },
+          {
+            "name" : "place",
+            "rel" : ["item","http://example.org/rels/place"],
+            "url" : "http://example.org/places/a",
             "data" : 
             [
               {
-                "name" : "create", 
-                "rel" : ["http://example.org/rels/create"], 
-                "url" : "http://example.org/people/",
-                "model" : "g={givenName}&f={familyName}&e={email}",
-                "action" : "append"
+                "name" : "name", 
+                "value" : "Home"
               },
               {
-                "name" : "search",
-                "rel" : ["search","collection"],
-                "url" : "http://example.org/people/search",
-                "model" : "?g={givenName}&f={familyName}&e={email}"
-              },
-              {
-                "name" : "person",
-                "rel" : ["item","http://example.org/rels/person"],
-                "url" : "http://example.org/people/1",
+                "name" : "address",
                 "data" :
                 [
-                  {"name" : "givenName", "value" : "Mike"},
-                  {"name" : "familyName", "value" : "Amundsen"},
-                  {"name" : "email", "value" : "mike@example.org"},
-                  {"name" : "avatarUrl", "transclude" : "true", 
-                      "url" : "http://example.org/avatars/1", 
-                      "value" : "User Photo",
-                      "accepting" : ["image/*"]
-                  }
-                ]
-              },
-              {
-                "name" : "person",
-                "rel" : ["item","http://example.org/rels/person"],
-                "url" : "http://example.org/people/2",
-                "data" :
-                [
-                  {"name" : "givenName", "value" : "Mildred"},
-                  {"name" : "familyName", "value" : "Amundsen"},
-                  {"name" : "email", "value" : "mildred@example.org"},
-                  {"name" : "avatarUrl", "transclude" : "true", 
-                      "url" : "http://example.org/avatars/2", 
-                      "value" : "User Photo",
-                      "accepting" : ["image/*"]
-                  }
+                  {"name" : "streetAddress", "value" : "123 Main Street"},
+                  {"name" : "addressLocalitly", "value" : "Byteville"},
+                  {"name" : "addressRegion", "value" : "MD"},
+                  {"name" : "postalCode", "value" : "12345"}
                 ]
               }
             ]
           },
-          
           {
-            "id" : "places", 
-            "rel" : ["collection","http://example.org/rels/places"], 
-            "url" : "http://example.org/places/",
-            "data" :
+            "name" : "place",
+            "rel" : ["item","http://example.org/rels/place"],
+            "url" : "http://example.org/places/b",
+            "data" : 
             [
               {
-                "name" : "search",
-                "rel" : ["search","collection"],
-                "url" : "http://example.org/places/search",
-                "model" : "?r={addressRegion}&l={addressLocality}&p={postalCode}"
+                "name" : "name", 
+                "value" : "Work"
               },
               {
-                "name" : "place",
-                "rel" : ["item","http://example.org/rels/place"],
-                "url" : "http://example.org/places/a",
+                "name" : "address",
                 "data" : 
                 [
-                  {
-                    "name" : "name", 
-                    "value" : "Home"
-                  },
-                  {
-                    "name" : "address",
-                    "data" :
-                    [
-                      {"name" : "streetAddress", "value" : "123 Main Street"},
-                      {"name" : "addressLocalitly", "value" : "Byteville"},
-                      {"name" : "addressRegion", "value" : "MD"},
-                      {"name" : "postalCode", "value" : "12345"}
-                    ]
-                  }
-                ]
-              },
-              {
-                "name" : "place",
-                "rel" : ["item","http://example.org/rels/place"],
-                "url" : "http://example.org/places/b",
-                "data" : 
-                [
-                  {
-                    "name" : "name", 
-                    "value" : "Work"
-                  },
-                  {
-                    "name" : "address",
-                    "data" : 
-                    [
-                      {"name" : "streetAddress", "value" : "1456 Grand Ave."},
-                      {"name" : "addressLocalitly", "value" : "Byteville"},
-                      {"name" : "addressRegion", "value" : "MD"},
-                      {"name" : "postalCode", "value" : "12345"}
-                    ]
-                  }
+                  {"name" : "streetAddress", "value" : "1456 Grand Ave."},
+                  {"name" : "addressLocalitly", "value" : "Byteville"},
+                  {"name" : "addressRegion", "value" : "MD"},
+                  {"name" : "postalCode", "value" : "12345"}
                 ]
               }
             ]


### PR DESCRIPTION
This took me a long while to figure out, but I think the JSON example needs some tweaking to make it the equivalent of the XML example. In the XML example, it looks like this (condensed):

``` xml
<uber version="1.0">
  <data rel="self" url="http://example.org/" />
  <data rel="profile" url="http://example.org/profiles/people-and-places/" />

  <data id="people" rel="collection http://example.org/rels/people" url="http://example.org/people/">
  </data>
</data>
```

The JSON variant is this (also condense, with comment to point out issue):

``` javascript
{
  "uber" :
  {
    "version" : "1.0",
    "data" :
    [
      {"rel" : ["self"], "url" : "http://example.org/"},
      {"rel" : ["profile"], "url" : "http://example.org/profiles/people-and-places"},

      {
        // Note this data element
        "data" :
        [
          {
            "id" : "people",
            "rel" : ["collection","http://example.org/rels/people"],
            "url" : "http://example.org/people/",
            "data" : []
          }
        ]
      }
    ]
  }
}
```

The item noted above makes for an extra, empty data element, which would be this in XML:

``` xml
<uber version="1.0">
  <data rel="self" url="http://example.org/" />
  <data rel="profile" url="http://example.org/profiles/people-and-places/" />

  <data>
    <data id="people" rel="collection http://example.org/rels/people" url="http://example.org/people/">
    </data>
  </data>
</data>
```

This pull request removes that extra data element. It's very hard to see without working with some code that is implementing this. To see the results in Hyperdescribe, view the [example in the repo](https://github.com/smizell/hyperdescribe-hal-json/blob/c849bffc63ee0ffabe2bad953ffe86bf23e94b45/examples/source.hyperdescribe.js).

Hope this makes sense. **Please check me to make sure I got this right!**
