### PR TITLE
Change transclude from string to boolean in JSON example

### DIFF
--- a/includes/full-example.js
+++ b/includes/full-example.js
@@ -34,7 +34,7 @@
               {"name" : "givenName", "value" : "Mike"},
               {"name" : "familyName", "value" : "Amundsen"},
               {"name" : "email", "value" : "mike@example.org"},
-              {"name" : "avatarUrl", "transclude" : "true", 
+              {"name" : "avatarUrl", "transclude" : true, 
                   "url" : "http://example.org/avatars/1", 
                   "value" : "User Photo",
                   "accepting" : ["image/*"]
@@ -50,7 +50,7 @@
               {"name" : "givenName", "value" : "Mildred"},
               {"name" : "familyName", "value" : "Amundsen"},
               {"name" : "email", "value" : "mildred@example.org"},
-              {"name" : "avatarUrl", "transclude" : "true", 
+              {"name" : "avatarUrl", "transclude" : true, 
                   "url" : "http://example.org/avatars/2", 
                   "value" : "User Photo",
                   "accepting" : ["image/*"]


### PR DESCRIPTION
I was working on the schema for this example and it failed with the transclude since it was a string and I was looking for a boolean. I changed the example on Hyperschema.org to make it validate. Do you want transclude to be a boolean in the JSON format?
